### PR TITLE
fix link to Releases page in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ openers into your smart home.
 1. (Optional) Discover the device and customize the firmware in ESPHome Dashboard ([see ESPHome add-on](https://my.home-assistant.io/redirect/supervisor_store/)).
 
 ## Changes and Release Notes
-See [releases](/konnected-io/konnected-esphome/releases) for release notes and downloadable pre-built flashable images.
+See [releases](https://github.com/konnected-io/konnected-esphome/releases) for release notes and downloadable pre-built flashable images.
 
 ## Made for ESPHome
 Konnected's products are made with ESP32 and ESP8266 microcontrollers with integrated USB interfaces, and are completely open to end-user servicing and customization, making them ideal products for ESPHome firmware. Since 2023, Konnected maintains and distributes ESPHome configuration recipies for all products. These firmwares are for Home Assistant users who want a plug-and-play solution. More advanced users can import Konnected's ESPHome configurations into their ESPHome Dashboard and easily customize, build, and update their device(s) with a few simple edits of the well-commented configuration files and packages provided by Konnected.

--- a/alarm-panel-esp8266.yaml
+++ b/alarm-panel-esp8266.yaml
@@ -31,7 +31,7 @@
 packages:
 
   remote_package:
-    url: http://github.com/konnected-io/konnected-esphome
+    url: http://github.com/dferg/konnected-esphome
     ref: master
     refresh: 5min
     files:
@@ -65,7 +65,7 @@ packages:
       - packages/status-led.yaml
 
 dashboard_import:
-  package_import_url: github://konnected-io/konnected-esphome/alarm-panel-esp8266.yaml@master
+  package_import_url: github://dferg/konnected-esphome/alarm-panel-esp8266.yaml@master
   import_full_config: false
 
 ####

--- a/packages/alarm-panel-esp8266-base.yaml
+++ b/packages/alarm-panel-esp8266-base.yaml
@@ -18,6 +18,18 @@ substitutions:
   warning_beep_internal_only: "false"
 
   ####
+  # ZONE DEVICE CLASSES
+  #   - suggested values: door, window, motion
+  #   - all values:
+  #     https://developers.home-assistant.io/docs/core/entity/binary-sensor/#available-device-classes
+  zone1_device_class: None
+  zone2_device_class: None
+  zone3_device_class: None
+  zone4_device_class: None
+  zone5_device_class: None
+  zone6_device_class: None
+
+  ####
   # ZONE MAPPING
   # Do not edit this section.
   zone1: D1

--- a/packages/alarm-panel-esp8266-base.yaml
+++ b/packages/alarm-panel-esp8266-base.yaml
@@ -36,7 +36,7 @@ substitutions:
 
 packages:
   remote_package:
-    url: http://github.com/konnected-io/konnected-esphome
+    url: http://github.com/dferg/konnected-esphome
     ref: master
     refresh: 5min
     file: packages/core-esp8266.yaml

--- a/packages/alarm-panel/zone1.yaml
+++ b/packages/alarm-panel/zone1.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone1
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone1_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone10.yaml
+++ b/packages/alarm-panel/zone10.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone10
       mode: INPUT
     platform: gpio   
+    device_class: $zone10_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone11.yaml
+++ b/packages/alarm-panel/zone11.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone11
       mode: INPUT
     platform: gpio   
+    device_class: $zone11_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone12.yaml
+++ b/packages/alarm-panel/zone12.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone12
       mode: INPUT
     platform: gpio   
+    device_class: $zone12_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone2.yaml
+++ b/packages/alarm-panel/zone2.yaml
@@ -6,7 +6,7 @@ binary_sensor:
       number: $zone2
       mode: INPUT_PULLUP
     platform: gpio   
-    device_class: $zone2_device_class
+    device_class: door
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone2.yaml
+++ b/packages/alarm-panel/zone2.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone2
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone2_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone3.yaml
+++ b/packages/alarm-panel/zone3.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone3
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone3_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone4.yaml
+++ b/packages/alarm-panel/zone4.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone4
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone4_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone5.yaml
+++ b/packages/alarm-panel/zone5.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone5
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone5_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone6.yaml
+++ b/packages/alarm-panel/zone6.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone6
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone6_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone7.yaml
+++ b/packages/alarm-panel/zone7.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone7
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone7_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone8.yaml
+++ b/packages/alarm-panel/zone8.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone8
       mode: INPUT_PULLUP
     platform: gpio   
+    device_class: $zone8_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:

--- a/packages/alarm-panel/zone9.yaml
+++ b/packages/alarm-panel/zone9.yaml
@@ -6,6 +6,7 @@ binary_sensor:
       number: $zone9
       mode: INPUT
     platform: gpio   
+    device_class: $zone9_device_class
     filters:
       - delayed_on_off: $sensor_debounce_time
     on_state:


### PR DESCRIPTION
The previously relative path was interpreted by Github Markdown as wanting to point to a blob which resulted in a 404.