### PR TITLE
fix: treat small distances as closed

### DIFF
--- a/packages/vl53l0x-range-sensor.yaml
+++ b/packages/vl53l0x-range-sensor.yaml
@@ -48,6 +48,8 @@ binary_sensor:
       float calibrated_distance = id(open_garage_door_distance_from_ceiling).state;
       if (std::isnan(id(range_sensor).state) || id(range_sensor).state > calibrated_distance + id(gdo_err_margin)) {
         return false;
+      } else if (id(range_sensor).state < 0 + id(gdo_err_margin)) {
+        return false;
       } else if (id(range_sensor).state > calibrated_distance - id(gdo_err_margin)){
         return true;
       } else {


### PR DESCRIPTION
My sensor reads small distances [0,0.05] when the door is closed, instead of a large distance or NA. Treat distances between 0 and the margin of error as closed.