### PR TITLE
Add door-open-chime.yaml and add option to set alarm output shared as false

### DIFF
--- a/packages/alarm-panel-esp32-base.yaml
+++ b/packages/alarm-panel-esp32-base.yaml
@@ -19,6 +19,7 @@ substitutions:
   warning_beep_pause_time: 130ms
   warning_beep_internal_only: "false"
   warning_beep_shared: "false"
+  alarm_shared: "true"
   blink_on_state: "true"
 
   ####

--- a/packages/alarm-panel-esp8266-base.yaml
+++ b/packages/alarm-panel-esp8266-base.yaml
@@ -17,6 +17,7 @@ substitutions:
   warning_beep_pause_time: 130ms
   warning_beep_internal_only: "false"
   warning_beep_shared: "true"
+  alarm_shared: "true"
   blink_on_state: "true"
 
   ####

--- a/packages/alarm-panel/alarm.yaml
+++ b/packages/alarm-panel/alarm.yaml
@@ -4,7 +4,7 @@ switch:
     name: Siren
     pin: 
       number: $alarm
-      allow_other_uses: true
+      allow_other_uses: $alarm_shared
     platform: gpio
     icon: mdi:bullhorn
     

--- a/packages/door-open-chime.yaml
+++ b/packages/door-open-chime.yaml
@@ -1,0 +1,25 @@
+output:
+  - id: 'chime_pin'
+    platform: gpio
+    pin:
+      number: $warning_beep_pin
+      allow_other_uses: $warning_beep_shared
+
+
+button:
+  - platform: template
+    id: buzzer
+    name: Buzzer
+    on_press:
+      - repeat:
+          count: $buzzer_repeat
+          then:
+            - output.turn_on: chime_pin
+            - delay: $buzzer_pulse
+            - output.turn_off: chime_pin
+            - delay: $buzzer_pause
+
+substitutions:
+  buzzer_pulse: 24ms
+  buzzer_pause: 54ms
+  buzzer_repeat: "6"


### PR DESCRIPTION
door-open-chime.yaml: Add a package that creates a virtual button that on press pulses on the selected output (usually connected to a piezo buzzer). This would typically be used as a chime to alert when a door has been opened.

alarm_shared: Adding a substitution to enable or disable whether the alarm output is shared. See issue https://github.com/konnected-io/konnected-esphome/issues/27. Default is set to true to follow the current standard.