### PR TITLE
secplus_gdo: Toggle updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ openers into your smart home.
 1. (Optional) Discover the device and customize the firmware in ESPHome Dashboard ([see ESPHome add-on](https://my.home-assistant.io/redirect/supervisor_store/)).
 
 ## Changes and Release Notes
-See [releases](/konnected-io/konnected-esphome/releases) for release notes and downloadable pre-built flashable images.
+See [releases](https://github.com/konnected-io/konnected-esphome/releases) for release notes and downloadable pre-built flashable images.
 
 ## Made for ESPHome
 Konnected's products are made with ESP32 and ESP8266 microcontrollers with integrated USB interfaces, and are completely open to end-user servicing and customization, making them ideal products for ESPHome firmware. Since 2023, Konnected maintains and distributes ESPHome configuration recipies for all products. These firmwares are for Home Assistant users who want a plug-and-play solution. More advanced users can import Konnected's ESPHome configurations into their ESPHome Dashboard and easily customize, build, and update their device(s) with a few simple edits of the well-commented configuration files and packages provided by Konnected.
@@ -61,6 +61,8 @@ LiftMaster, Craftsman and Merlin brands.
 #### This component is maintained by Konnected and powers the [Konnected GDO blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative) Konnected's smart garage door opener accessory for Security+ garage door openers.
 
 #### Documentation
+
+See [README](https://github.com/konnected-io/konnected-esphome/tree/master/components/secplus_gdo)
 
 #### Adapted from [ratgdo](https://github.com/ratgdo)
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ LiftMaster, Craftsman and Merlin brands.
 
 #### This component is maintained by Konnected and powers the [Konnected GDO blaQ](https://konnected.io/products/smart-garage-door-opener-blaq-myq-alternative) Konnected's smart garage door opener accessory for Security+ garage door openers.
 
+#### Documentation
+
 #### Adapted from [ratgdo](https://github.com/ratgdo)
 
 This component was adapted from and inspired by [ratgdo](https://paulwieland.github.io/ratgdo/), however it's not a copy and not feature-equivalent. We initially set out to fork ratgdo and contribute back some improvements, however it ultimately became a complete rewrite. Konnected is publishing this derivative work under the GPLv3 license.
@@ -81,9 +83,10 @@ The ratgdo and [secplus](https://github.com/argilo/secplus) developers found a w
 1. *Removes dry contact trigger support*. We feel that this is better handled with a _template cover_ in ESPHome, and this library should focus on the Security+ interaction only.
 1. *Removes relay outputs*. Again, simplifying the library to do Security+ only.
 
-#### Dependencies
+#### Noted Dependencies
 
-1. [gdolib](https://github.com/konnected-io/gdolib) (to be published soon)
+1. [gdolib](https://github.com/konnected-io/gdolib)
+1. [secplus](https://github.com/argilo/secplus)
 
 ## Customization
 

--- a/components/secplus_gdo/README.md
+++ b/components/secplus_gdo/README.md
@@ -2,7 +2,7 @@
 
 ## Documentation and Example Usage
 
-See [packages/secplus-gdo.yaml](../packages/secplus-gdo.yaml) for a complete example.
+See [packages/secplus-gdo.yaml](https://github.com/konnected-io/konnected-esphome/blob/master/packages/secplus-gdo.yaml) for a complete example.
 
 ### Setup
 Import the component into your ESPHome config:

--- a/components/secplus_gdo/README.md
+++ b/components/secplus_gdo/README.md
@@ -1,0 +1,44 @@
+# secplus_gdo
+
+## Documentation and Example Usage
+
+See [packages/secplus-gdo.yaml](../packages/secplus-gdo.yaml) for a complete example.
+
+### Setup
+Import the component into your ESPHome config:
+
+```
+external_components:
+  - source: github://konnected-io/konnected-esphome@master
+    components: [ secplus_gdo ]
+```
+
+Include the component:
+```
+secplus_gdo:
+  id: gdo_blaq
+  input_gdo_pin: ${uart_rx_pin}
+  output_gdo_pin: ${uart_tx_pin}
+```
+
+### Cover
+
+```
+cover:
+  - platform: secplus_gdo
+    name: Garage Door
+    secplus_gdo_id: gdo_blaq
+    id: gdo_door
+    pre_close_warning_duration: 5s
+    pre_close_warning_start:
+      - button.press: pre_close_warning
+
+```
+
+#### Configuration options
+
+* **secplus_gdo_id** (**Required**, string): The ID of the component set above.
+* **pre_close_warning_duration** (_Optional_, Time): Duration of the pre-close warning
+* **pre_close_warning_start** (_Optional_, Action): Action(s) to execute the pre-close warning
+* **pre_close_warning_end** (_Optional_, Action): Action(s) to execute when the pre-close warning stops
+* **toggle_only** (_Optional_, boolean)_: When true, all open/close commands are sent as a toggle door actions to the garage opener. This is a compatibility fix for some openers, such as some Merlin brand openers that are known to only respond to toggle commands and don't respond to discrete open/close commands.

--- a/components/secplus_gdo/cover/__init__.py
+++ b/components/secplus_gdo/cover/__init__.py
@@ -40,6 +40,7 @@ CoverClosingEndTrigger = secplus_gdo_ns.class_(
 CONF_PRE_CLOSE_WARNING_DURATION = "pre_close_warning_duration"
 CONF_PRE_CLOSE_WARNING_START = "pre_close_warning_start"
 CONF_PRE_CLOSE_WARNING_END = "pre_close_warning_end"
+CONF_TOGGLE_ONLY = "toggle_only"
 
 CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
     {
@@ -51,6 +52,7 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
         cv.Optional(CONF_PRE_CLOSE_WARNING_END): automation.validate_automation(
             {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverClosingEndTrigger)}
         ),
+        cv.Optional(CONF_TOGGLE_ONLY, default=False): cv.boolean,
     }
 ).extend(SECPLUS_GDO_CONFIG_SCHEMA)
 
@@ -63,6 +65,7 @@ async def to_code(config):
     text = "std::bind(&" + str(GDODoor) + "::set_state," + str(config[CONF_ID]) + ",std::placeholders::_1,std::placeholders::_2)"
     cg.add(parent.register_door(cg.RawExpression(text)))
     cg.add(var.set_pre_close_warning_duration(config[CONF_PRE_CLOSE_WARNING_DURATION]))
+    cg.add(var.set_toggle_only(config[CONF_TOGGLE_ONLY]))
     for conf in config.get(CONF_PRE_CLOSE_WARNING_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -90,12 +90,22 @@ void GDODoor::do_action(const cover::CoverCall& call) {
         auto pos = *call.get_position();
         if (pos == COVER_OPEN) {
             this->set_state(GDO_DOOR_STATE_OPENING, this->position);
-            ESP_LOGD(TAG, "Sending OPEN action");
-            gdo_door_open();
+            if (this->toggle_only_) {
+                ESP_LOGD(TAG, "Sending TOGGLE action");
+                gdo_door_toggle();
+            } else {
+                ESP_LOGD(TAG, "Sending OPEN action");
+                gdo_door_open();
+            }
         } else if (pos == COVER_CLOSED) {            
             this->set_state(GDO_DOOR_STATE_CLOSING, this->position);
-            ESP_LOGD(TAG, "Sending CLOSE action");
-            gdo_door_close();
+            if (this->toggle_only_) {
+                ESP_LOGD(TAG, "Sending TOGGLE action");
+                gdo_door_toggle();
+            } else {
+                ESP_LOGD(TAG, "Sending CLOSE action");
+                gdo_door_close();
+            }
         } else {
             ESP_LOGD(TAG, "Moving garage door to position %f", pos);
             gdo_door_move_to_target(10000 - (pos * 10000));

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -51,57 +51,78 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
     this->publish_state(false);
 }
 
-void GDODoor::start_pre_close(uint32_t pos) {
+void GDODoor::do_action_after_warning(const cover::CoverCall& call) {
     if (this->pre_close_active_) {
         return;
     }
 
+    ESP_LOGD(TAG, "WARNING for %dms", this->pre_close_duration_);
     if (this->pre_close_start_trigger) {
         this->pre_close_start_trigger->trigger();
     }
-
-    this->set_state(GDO_DOOR_STATE_CLOSING, this->position);
 
     this->set_timeout("pre_close", this->pre_close_duration_, [=]() {
         this->pre_close_active_ = false;
         if (this->pre_close_end_trigger) {
             this->pre_close_end_trigger->trigger();
         }
-
-        if (pos > 0) {
-            ESP_LOGD(TAG, "Moving door to position %d", pos);
-            gdo_door_move_to_target(pos);
-        } else {
-            ESP_LOGD(TAG, "Closing door");
-            gdo_door_close();
-        }
+        this->do_action(call);
     });
 
     this->pre_close_active_ = true;
+}
+
+void GDODoor::do_action(const cover::CoverCall& call) {
+    if (call.get_stop()) {
+        ESP_LOGD(TAG, "Sending STOP action");
+        gdo_door_stop();
+    }
+    if (call.get_toggle()) {        
+        if (this->position == COVER_CLOSED) {
+            this->set_state(GDO_DOOR_STATE_OPENING, this->position);
+        } else if (this->position == COVER_OPEN) {
+            this->set_state(GDO_DOOR_STATE_CLOSING, this->position);
+        }
+        ESP_LOGD(TAG, "Sending TOGGLE action");
+        gdo_door_toggle();
+    }
+    if (call.get_position().has_value()) {
+        auto pos = *call.get_position();
+        if (pos == COVER_OPEN) {
+            this->set_state(GDO_DOOR_STATE_OPENING, this->position);
+            ESP_LOGD(TAG, "Sending OPEN action");
+            gdo_door_open();
+        } else if (pos == COVER_CLOSED) {            
+            this->set_state(GDO_DOOR_STATE_CLOSING, this->position);
+            ESP_LOGD(TAG, "Sending CLOSE action");
+            gdo_door_close();
+        } else {
+            ESP_LOGD(TAG, "Moving garage door to position %f", pos);
+            gdo_door_move_to_target(10000 - (pos * 10000));
+        }
+    }
 }
 
 void GDODoor::control(const cover::CoverCall& call) {
     if (call.get_stop()) {
         ESP_LOGD(TAG, "Stop command received");
         if (this->pre_close_active_) {
-            ESP_LOGD(TAG, "Canceling pre-close warning");
+            ESP_LOGD(TAG, "Canceling pending action");
             this->cancel_timeout("pre_close");
             this->pre_close_active_ = false;
             if (this->pre_close_end_trigger) {
                 this->pre_close_end_trigger->trigger();
             }
-            this->set_state(GDO_DOOR_STATE_OPEN, this->position);
         }
-
-        gdo_door_stop();
+        this->do_action(call);
     }
 
     if (call.get_toggle()) {
         ESP_LOGD(TAG, "Toggle command received");
         if (this->position != COVER_CLOSED) {
-            this->start_pre_close(0);
+            this->do_action_after_warning(call);
         } else {
-            gdo_door_toggle();
+            this->do_action(call);
         }
     }
 
@@ -109,7 +130,7 @@ void GDODoor::control(const cover::CoverCall& call) {
         auto pos = *call.get_position();
 
         if (this->pre_close_active_) {
-            ESP_LOGD(TAG, "Canceling pre-close warning");
+            ESP_LOGD(TAG, "Canceling pending action");
             this->cancel_timeout("pre_close");
             this->pre_close_active_ = false;
             if (this->pre_close_end_trigger) {
@@ -119,22 +140,24 @@ void GDODoor::control(const cover::CoverCall& call) {
 
         if (this->current_operation == COVER_OPERATION_OPENING ||
             this->current_operation == COVER_OPERATION_CLOSING) {
-            ESP_LOGD(TAG, "Stopping door in motion");
+            ESP_LOGD(TAG, "Door is in motion - Sending STOP action");
             gdo_door_stop();
         }
 
         if (pos == COVER_OPEN) {
             ESP_LOGD(TAG, "Open command received");
-            gdo_door_open();
+            this->do_action(call);
         } else if (pos == COVER_CLOSED) {
             ESP_LOGD(TAG, "Close command received");
-            this->start_pre_close();
+            this->do_action_after_warning(call);
         } else {
-            ESP_LOGD(TAG, "Move to position command received");
+            ESP_LOGD(TAG, "Move to position %f command received", pos);
             if (pos < this->position) {
-                this->start_pre_close(10000 - (pos * 10000));
+                ESP_LOGV(TAG, "Current position: %f; Intended position: %f; Door will move down after warning", this->position, pos);
+                this->do_action_after_warning(call);
             } else {
-                gdo_door_move_to_target(10000 - (pos * 10000));
+                ESP_LOGV(TAG, "Current position: %f; Intended position: %f; Door will move up immediately", this->position, pos);
+                this->do_action(call);
             }
         }
     }

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -44,7 +44,8 @@ using namespace esphome::cover;
             this->pre_close_end_trigger = trigger;
         }
 
-        void start_pre_close(uint32_t pos = 0);
+        void do_action(const cover::CoverCall& call);
+        void do_action_after_warning(const cover::CoverCall& call);        
         void set_pre_close_warning_duration(uint32_t ms) { this->pre_close_duration_ = ms; }
         void set_state(gdo_door_state_t state, float position);
 

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -47,6 +47,7 @@ using namespace esphome::cover;
         void do_action(const cover::CoverCall& call);
         void do_action_after_warning(const cover::CoverCall& call);        
         void set_pre_close_warning_duration(uint32_t ms) { this->pre_close_duration_ = ms; }
+        void set_toggle_only(bool val) { this->toggle_only_ = val; }
         void set_state(gdo_door_state_t state, float position);
 
     protected:
@@ -54,8 +55,9 @@ using namespace esphome::cover;
 
         CoverClosingStartTrigger *pre_close_start_trigger{nullptr};
         CoverClosingEndTrigger   *pre_close_end_trigger{nullptr};
-        uint32_t                 pre_close_duration_{0};
+        uint32_t                 pre_close_duration_{0};        
         bool                     pre_close_active_{false};
+        bool                     toggle_only_{false};
     };
 } // namespace secplus_gdo
 } // namespace esphome


### PR DESCRIPTION
This is a better approach to #46 I think. This change does two things:

1. When the _toggle_ cover action is called, the _toggle_ door action is sent instead of translating that into an _open_ or _close_. This makes it consistent with the user/client expectation.
2. Adds a `toggle_only` option to the cover config. When true, all open/close commands are sent as a _toggle_ door actions to the garage opener. This is a compatibility fix for some openers, such as Merlin brands in Australia ([reddit thread](https://www.reddit.com/r/ratgdo/comments/193qdbm/seeking_help_to_setup_my_ratgdo_25i_with_my/)) that are known to only respond to toggle commands and don't respond to discrete open/close commands.