### PR TITLE
Update alarm-panel-pro-esp32-ethernet.yaml

### DIFF
--- a/alarm-panel-pro-esp32-ethernet.yaml
+++ b/alarm-panel-pro-esp32-ethernet.yaml
@@ -84,7 +84,7 @@ substitutions:
 packages:
 
   remote_package:
-    url: http://github.com/konnected-io/konnected-esphome
+    url: https://github.com/konnected-io/konnected-esphome
     ref: master
     refresh: 5min
     files:


### PR DESCRIPTION
switch to HTTPS for better security instead of HTTP