### PR TITLE
cleanup warning beep package for simpler basic usage

### DIFF
--- a/alarm-panel-esp8266.yaml
+++ b/alarm-panel-esp8266.yaml
@@ -38,14 +38,14 @@ substitutions:
   name: konnected
   friendly_name: Alarm Panel
   project_name: konnected.alarm-panel-esp8266
-  project_version: "1.1.0"
+  project_version: "1.1.1"
 
   ####
   # SETTINGS
   sensor_debounce_time: 200ms
   warning_beep_pulse_time: 100ms
   warning_beep_pause_time: 130ms
-  warning_beep_internal_only: "false"
+  warning_beep_name: Warning Beep
   warning_beep_shared: "true"
   blink_on_state: "true"
 
@@ -100,26 +100,12 @@ packages:
       # Enables the onboard blue status LED as an activity/error indicator
       - packages/status-led.yaml
 
-  ####
-  # WARNING BEEP
-  # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
-  # binary output This is implemented using the light component with strobe effect to create a 
-  # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
-  #
-  # Here we include one _Warning Beep_ by default, but you can copy/paste this section to create
-  # different pulsing effects on the same or different outputs.
-  remote_package_warning_beep: !include
-    url: https://github.com/konnected-io/konnected-esphome
-    ref: master
-    refresh: 5min
-    file: packages/warning-beep.yaml
-    vars:
-      warning_beep_name: Warning Beep
-      warning_beep_pin: $warning_beep_pin
-      warning_beep_pulse_time: $warning_beep_pulse_time
-      warning_beep_pause_time: $warning_beep_pause_time
-      warning_beep_shared: $warning_beep_shared
-      warning_beep_internal_only: $warning_beep_internal_only
+      ####
+      # WARNING BEEP
+      # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
+      # binary output This is implemented using the light component with strobe effect to create a 
+      # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
+      - packages/warning-beep.yaml
 
 dashboard_import:
   package_import_url: github://konnected-io/konnected-esphome/alarm-panel-esp8266.yaml@master

--- a/alarm-panel-pro-esp32-ethernet.yaml
+++ b/alarm-panel-pro-esp32-ethernet.yaml
@@ -38,7 +38,7 @@ substitutions:
   name: konnected
   friendly_name: Alarm Panel Pro
   project_name: konnected.alarm-panel-pro-ethernet
-  project_version: "1.1.0"
+  project_version: "1.1.1"
 
   # ETHERNET CONFIG
   # On the Alarm Panel Pro v1.5, v1.6 and v1.7 use LAN8720. On the v1.8 set this variable to RTL8201.
@@ -123,27 +123,13 @@ packages:
       # OUTPUTS
       - packages/alarm-panel/alarm1.yaml
       - packages/alarm-panel/alarm2.yaml
-  
-  ####
-  # WARNING BEEP
-  # Enables a 'Warning Beep' output, intended to be used with a piezo buzzer or other pulsing.
-  # binary output This is implemented using the light component with strobe effect to create a 
-  # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
-  #
-  # Here we include one _Warning Beep_ by default, but you can copy/paste this section to create
-  # different pulsing effects on the same or different outputs.
-  remote_package_warning_beep: !include
-    url: https://github.com/konnected-io/konnected-esphome
-    ref: master
-    refresh: 5min
-    file: packages/warning-beep.yaml
-    vars:
-      warning_beep_name: Warning Beep
-      warning_beep_pin: $warning_beep_pin
-      warning_beep_pulse_time: $warning_beep_pulse_time
-      warning_beep_pause_time: $warning_beep_pause_time
-      warning_beep_shared: $warning_beep_shared
-      warning_beep_internal_only: $warning_beep_internal_only
+
+      ####
+      # WARNING BEEP
+      # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
+      # binary output This is implemented using the light component with strobe effect to create a 
+      # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
+      - packages/warning-beep.yaml
   
 dashboard_import:
   package_import_url: github://konnected-io/konnected-esphome/alarm-panel-pro-esp32-ethernet.yaml@master

--- a/alarm-panel-pro-esp32-local-alarm.yaml
+++ b/alarm-panel-pro-esp32-local-alarm.yaml
@@ -33,7 +33,7 @@ substitutions:
   name: alarm-panel-pro
   friendly_name: Alarm Panel Pro
   project_name: konnected.alarm-panel-pro-esp32-local
-  project_version: "0.2.0"
+  project_version: "0.2.1"
 
   sensor_debounce_time: 200ms
   warning_beep_pulse_time: 100ms
@@ -375,26 +375,12 @@ packages:
       - packages/alarm-panel/alarm1.yaml
       - packages/alarm-panel/alarm2.yaml
 
-  ####
-  # WARNING BEEP
-  # Enables a 'Warning Beep' output, intended to be used with a piezo buzzer or other pulsing.
-  # binary output This is implemented using the light component with strobe effect to create a 
-  # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
-  #
-  # Here we include one _Warning Beep_ by default, but you can copy/paste this section to create
-  # different pulsing effects on the same or different outputs.
-  remote_package_warning_beep: !include
-    url: http://github.com/konnected-io/konnected-esphome
-    ref: master
-    refresh: 5min
-    file: packages/warning-beep.yaml
-    vars:
-      warning_beep_name: Warning Beep
-      warning_beep_pin: $warning_beep_pin
-      warning_beep_pulse_time: $warning_beep_pulse_time
-      warning_beep_pause_time: $warning_beep_pause_time
-      warning_beep_shared: $warning_beep_shared
-      warning_beep_internal_only: $warning_beep_internal_only
+      ####
+      # WARNING BEEP
+      # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
+      # binary output This is implemented using the light component with strobe effect to create a 
+      # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
+      - packages/warning-beep.yaml
 
 
 dashboard_import:

--- a/alarm-panel-pro-esp32-wifi.yaml
+++ b/alarm-panel-pro-esp32-wifi.yaml
@@ -120,26 +120,12 @@ packages:
       - packages/alarm-panel/alarm1.yaml
       - packages/alarm-panel/alarm2.yaml
 
-  ####
-  # WARNING BEEP
-  # Enables a 'Warning Beep' output, intended to be used with a piezo buzzer or other pulsing.
-  # binary output This is implemented using the light component with strobe effect to create a 
-  # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
-  #
-  # Here we include one _Warning Beep_ by default, but you can copy/paste this section to create
-  # different pulsing effects on the same or different outputs.
-  remote_package_warning_beep: !include
-    url: https://github.com/konnected-io/konnected-esphome
-    ref: master
-    refresh: 5min
-    file: packages/warning-beep.yaml
-    vars:
-      warning_beep_name: Warning Beep
-      warning_beep_pin: $warning_beep_pin
-      warning_beep_pulse_time: $warning_beep_pulse_time
-      warning_beep_pause_time: $warning_beep_pause_time
-      warning_beep_shared: $warning_beep_shared
-      warning_beep_internal_only: $warning_beep_internal_only
+      ####
+      # WARNING BEEP
+      # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
+      # binary output This is implemented using the light component with strobe effect to create a 
+      # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
+      - packages/warning-beep.yaml
 
 dashboard_import:
   package_import_url: github://konnected-io/konnected-esphome/alarm-panel-pro-esp32-wifi.yaml@master

--- a/alarm-panel-pro-v1.8-ethernet.yaml
+++ b/alarm-panel-pro-v1.8-ethernet.yaml
@@ -124,26 +124,12 @@ packages:
       - packages/alarm-panel/alarm1.yaml
       - packages/alarm-panel/alarm2.yaml
 
-  ####
-  # WARNING BEEP
-  # Enables a 'Warning Beep' output, intended to be used with a piezo buzzer or other pulsing.
-  # binary output This is implemented using the light component with strobe effect to create a 
-  # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
-  #
-  # Here we include one _Warning Beep_ by default, but you can copy/paste this section to create
-  # different pulsing effects on the same or different outputs.
-  remote_package_warning_beep: !include
-    url: https://github.com/konnected-io/konnected-esphome
-    ref: master
-    refresh: 5min
-    file: packages/warning-beep.yaml
-    vars:
-      warning_beep_name: Warning Beep
-      warning_beep_pin: $warning_beep_pin
-      warning_beep_pulse_time: $warning_beep_pulse_time
-      warning_beep_pause_time: $warning_beep_pause_time
-      warning_beep_shared: $warning_beep_shared
-      warning_beep_internal_only: $warning_beep_internal_only
+      ####
+      # WARNING BEEP
+      # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
+      # binary output This is implemented using the light component with strobe effect to create a 
+      # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
+      - packages/warning-beep.yaml
   
 dashboard_import:
   package_import_url: github://konnected-io/konnected-esphome/alarm-panel-pro-v1.8-ethernet.yaml@master

--- a/examples/alarm-panel-pro-local-alarm.yaml
+++ b/examples/alarm-panel-pro-local-alarm.yaml
@@ -88,26 +88,12 @@ packages:
       - packages/alarm-panel/alarm1.yaml
       # - packages/alarm-panel/alarm2.yaml
 
-  ####
-  # WARNING BEEP
-  # Enables a 'Warning Beep' output, intended to be used with a piezo buzzer or other pulsing.
-  # binary output This is implemented using the light component with strobe effect to create a 
-  # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
-  #
-  # Here we include one _Warning Beep_ by default, but you can copy/paste this section to create
-  # different pulsing effects on the same or different outputs.
-  remote_package_warning_beep: !include
-    url: https://github.com/konnected-io/konnected-esphome
-    ref: master
-    refresh: 5min
-    file: packages/warning-beep.yaml
-    vars:
-      warning_beep_name: Warning Beep
-      warning_beep_pin: $warning_beep_pin
-      warning_beep_pulse_time: $warning_beep_pulse_time
-      warning_beep_pause_time: $warning_beep_pause_time
-      warning_beep_shared: $warning_beep_shared
-      warning_beep_internal_only: $warning_beep_internal_only
+      ####
+      # WARNING BEEP
+      # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
+      # binary output This is implemented using the light component with strobe effect to create a 
+      # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
+      - packages/warning-beep.yaml
 
 ####
 # Zone Customization

--- a/garage-door-GDOv1-S.yaml
+++ b/garage-door-GDOv1-S.yaml
@@ -53,9 +53,10 @@ substitutions:
   name: konnected
   friendly_name: Garage Door Opener
   project_name: konnected.garage-door-gdov1-s
-  project_version: "1.2.0"
+  project_version: "1.2.1"
   garage_door_cover_name: Garage Door
   switch_name: Switch
+  warning_beep_name: Warning Beep
 
   ####
   # GARAGE DOOR OPENER MOMENTARY DURATION
@@ -163,25 +164,12 @@ packages:
       # Enables the onboard blue status LED as an activity/error indicator
       - packages/status-led.yaml
 
-  ####
-  # WARNING BEEP
-  # Enables a 'Warning Beep' output, intended to be used with a piezo buzzer or other pulsing.
-  # binary output This is implemented using the light component with strobe effect to create a 
-  # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
-  #
-  # Here we include one _Warning Beep_ by default, but you can copy/paste this section to create
-  # different pulsing effects on the same or different outputs.
-  remote_package_warning_beep: !include
-    url: https://github.com/konnected-io/konnected-esphome
-    ref: master
-    refresh: 5min
-    file: packages/warning-beep.yaml
-    vars:
-      warning_beep_pin: $warning_beep_pin
-      warning_beep_pulse_time: $warning_beep_pulse_time
-      warning_beep_pause_time: $warning_beep_pause_time
-      warning_beep_shared: False
-      warning_beep_internal_only: True
+      ####
+      # WARNING BEEP
+      # Enables a 'Warning Beep' entity, intended to be used with a piezo buzzer or other pulsing.
+      # binary output This is implemented using the light component with strobe effect to create a 
+      # repeated beeping sound or pulsing action that can be turned on via the _strobe_ effect.
+      - packages/warning-beep.yaml
 
 ####
 # DASHBOARD IMPORT

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: GDO blaQ
   project_name: konnected.garage-door-gdov2-q
-  project_version: "1.0.0"
+  project_version: "1.0.1"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings

--- a/garage-door-GDOv2-S.yaml
+++ b/garage-door-GDOv2-S.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: Garage Door Opener
   project_name: konnected.garage-door-gdov2-s
-  project_version: "1.2.0"
+  project_version: "1.2.1"
   garage_door_cover_name: Garage Door
   switch_name: STR output
 

--- a/packages/warning-beep.yaml
+++ b/packages/warning-beep.yaml
@@ -1,8 +1,8 @@
-defaults:
+substitutions:
   warning_beep_index: '1'
   warning_beep_name: Warning Beep
-  warning_beep_shared: False
-  warning_beep_internal_only: False
+  warning_beep_shared: 'false'
+  warning_beep_internal_only: 'false'
 
 output:
   - id: buzzer_out_${warning_beep_index}


### PR DESCRIPTION
In the last release I refactored the `warning-beep.yaml` package to be templatable, not realizing that external packages can not use template variables! This broke people's ESPHome dashboard updates/builds for the GDOv1. 

This cleans up the warning-beep.yaml package so that it can be included without required template vars, but when used as a local package it still allows for templating 😉 

Also it makes basic usage simpler, like it was originally.