### PR TITLE
Adds `client_id` and `rolling_code` number sensors and set them as internal only

### DIFF
--- a/components/secplus_gdo/number/__init__.py
+++ b/components/secplus_gdo/number/__init__.py
@@ -32,6 +32,8 @@ CONF_TYPE = "type"
 TYPES = {
     "open_duration": "register_open_duration",
     "close_duration": "register_close_duration",
+    "client_id": "register_client_id",
+    "rolling_code": "register_rolling_code",
 }
 
 CONFIG_SCHEMA = (
@@ -46,7 +48,12 @@ CONFIG_SCHEMA = (
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
-    await number.register_number(var, config, min_value=0, max_value=65535, step=1)
+    if "duration" in str(config[CONF_TYPE]):
+        await number.register_number(var, config, min_value=0x0, max_value=0xffff, step=1)
+    elif "client_id" in str(config[CONF_TYPE]):
+        await number.register_number(var, config, min_value=0x666, max_value=0x7ff666, step=1)
+    else:
+        await number.register_number(var, config, min_value=0x0, max_value=0xffffffff, step=1)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
     fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])

--- a/components/secplus_gdo/number/gdo_number.h
+++ b/components/secplus_gdo/number/gdo_number.h
@@ -37,8 +37,8 @@ class GDONumber : public number::Number, public Component {
             this->control(value);
         }
 
-        void update_state(float value, bool replace = false) {
-            if (this->state > 0 && !replace) {
+        void update_state(float value) {
+            if (value == this->state) {
                 return;
             }
 

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -32,6 +32,8 @@ namespace secplus_gdo {
             ESP_LOGI(TAG, "Synced: %s, protocol: %s", status->synced ? "true" : "false", gdo_protocol_type_to_string(status->protocol));
             if (status->protocol == GDO_PROTOCOL_SEC_PLUS_V2) {
                 ESP_LOGI(TAG, "Client ID: %" PRIu32 ", Rolling code: %" PRIu32, status->client_id, status->rolling_code);
+                gdo->set_client_id(status->client_id);
+                gdo->set_rolling_code(status->rolling_code);
             }
 
             if (!status->synced) {

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -71,6 +71,12 @@ namespace secplus_gdo {
         void register_close_duration(GDONumber* num) { close_duration_ = num; }
         void set_close_duration(uint16_t ms ) { if (close_duration_) { close_duration_->update_state(ms); } }
 
+        void register_client_id(GDONumber* num) { client_id_ = num; }
+        void set_client_id(uint32_t num) { if (client_id_) { client_id_->update_state(num); } }
+
+        void register_rolling_code(GDONumber* num) { rolling_code_ = num; }
+        void set_rolling_code(uint32_t num) { if (rolling_code_) { rolling_code_->update_state(num); } }
+
     protected:
         gdo_status_t status_;
         std::function<void(gdo_door_state_t, float)> f_door{nullptr};
@@ -84,6 +90,8 @@ namespace secplus_gdo {
         std::function<void(bool)>                    f_learn{nullptr};
         GDONumber*                                   open_duration_{nullptr};
         GDONumber*                                   close_duration_{nullptr};
+        GDONumber*                                   client_id_{nullptr};
+        GDONumber*                                   rolling_code_{nullptr};
         GDOSelect*                                   protocol_select_{nullptr};
 
     }; // GDOComponent

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: GDO blaQ
   project_name: konnected.garage-door-gdov2-q
-  project_version: "1.0.3"
+  project_version: "1.0.4"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings
@@ -65,7 +65,7 @@ substitutions:
   garage_motion_name: Motion
   garage_obstruction_name: Obstruction
   garage_motor_name: Motor
-  garage_button_name: Button
+  garage_button_name: Wall Button
 
 
   ####

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -89,7 +89,7 @@ substitutions:
   status_led: GPIO18
 
 external_components:
-  - source: github://konnected-io/konnected-esphome@master
+  - source: github://konnected-io/konnected-esphome@oz-fix
     components: [ mdns, secplus_gdo ]
 
   # Un-comment below and comment above for local modification
@@ -97,7 +97,7 @@ external_components:
   #     type: local
   #     path: components
   #   components: [ secplus_gdo ]
-  
+
 ####
 # PACKAGES
 # Each package includes a Garage Door Opener feature described
@@ -106,7 +106,7 @@ packages:
 
   remote_package:
     url: https://github.com/konnected-io/konnected-esphome
-    ref: master
+    ref: oz-fix
     refresh: 5min
     files:
 
@@ -155,7 +155,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@master
+  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@oz-fix
   import_full_config: false
 
 ####

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -89,7 +89,7 @@ substitutions:
   status_led: GPIO18
 
 external_components:
-  - source: github://konnected-io/konnected-esphome@oz-fix
+  - source: github://konnected-io/konnected-esphome@master
     components: [ mdns, secplus_gdo ]
 
   # Un-comment below and comment above for local modification
@@ -106,7 +106,7 @@ packages:
 
   remote_package:
     url: https://github.com/konnected-io/konnected-esphome
-    ref: oz-fix
+    ref: master
     refresh: 5min
     files:
 
@@ -155,7 +155,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@oz-fix
+  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@master
   import_full_config: false
 
 ####

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: GDO blaQ
   project_name: konnected.garage-door-gdov2-q
-  project_version: "1.0.4"
+  project_version: "1.1.0"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -189,7 +189,6 @@ esp32_improv:
   authorizer: false
 
 web_server:
-  include_internal: true
 
 esphome:
   platformio_options:

--- a/packages/core-esp32-s3.yaml
+++ b/packages/core-esp32-s3.yaml
@@ -46,4 +46,5 @@ sensor:
 button:
   - platform: restart
     name: Restart
+    id: restart_button
     entity_category: config

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -88,6 +88,25 @@ button:
   - platform: factory_reset
     name: Factory Reset
     entity_category: config
+  - platform: template
+    name: Reset door timings
+    on_press:
+      - number.set:
+          id: gdo_open_duration
+          value: 0
+      - number.set:
+          id: gdo_close_duration
+          value: 0
+      - button.press:
+          id: restart_button
+  - platform: template
+    name: Re-sync
+    on_press:
+      - number.increment:
+          id: gdo_client_id
+      - button.press:
+          id: restart_button
+
 
 number:
   - platform: secplus_gdo

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -59,13 +59,12 @@ binary_sensor:
     name: $garage_motor_name
     id: gdo_motor
     secplus_gdo_id: gdo_blaq
-    entity_category: diagnostic
+    device_class: running
     type: motor
   - platform: secplus_gdo
     name: $garage_button_name
     id: gdo_button
     secplus_gdo_id: gdo_blaq
-    entity_category: diagnostic
     type: button
 
 switch:

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -98,6 +98,7 @@ number:
     id: gdo_open_duration
     type: open_duration
     unit_of_measurement: "ms"
+    internal: true
 
   - platform: secplus_gdo
     name: Closing duration
@@ -106,6 +107,7 @@ number:
     id: gdo_close_duration
     type: close_duration
     unit_of_measurement: "ms"
+    internal: true
 
   - platform: secplus_gdo
     name: Client ID
@@ -114,6 +116,7 @@ number:
     id: gdo_client_id
     type: client_id
     mode: box
+    internal: true
 
   - platform: secplus_gdo
     name: Rolling Code
@@ -122,3 +125,4 @@ number:
     id: gdo_rolling_code
     type: rolling_code
     mode: box
+    internal: true

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -106,3 +106,19 @@ number:
     id: gdo_close_duration
     type: close_duration
     unit_of_measurement: "ms"
+
+  - platform: secplus_gdo
+    name: Client ID
+    secplus_gdo_id: gdo_blaq
+    entity_category: config
+    id: gdo_client_id
+    type: client_id
+    mode: box
+
+  - platform: secplus_gdo
+    name: Rolling Code
+    secplus_gdo_id: gdo_blaq
+    entity_category: config
+    id: gdo_rolling_code
+    type: rolling_code
+    mode: box

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -69,12 +69,11 @@ binary_sensor:
 
 switch:
   - platform: secplus_gdo
-    id: "gdo_learn"
+    id: gdo_learn
     type: learn
     secplus_gdo_id: gdo_blaq
-    name: "Learn"
+    name: Learn
     icon: mdi:plus-box
-    entity_category: config
 
 select:
   - platform: secplus_gdo
@@ -90,6 +89,7 @@ button:
     entity_category: config
   - platform: template
     name: Reset door timings
+    entity_category: config
     on_press:
       - number.set:
           id: gdo_open_duration
@@ -101,6 +101,7 @@ button:
           id: restart_button
   - platform: template
     name: Re-sync
+    entity_category: config
     on_press:
       - number.increment:
           id: gdo_client_id


### PR DESCRIPTION
Adds internal number sensors to track `client_id` and `rolling_code`. Also cleans up some sensor naming, categories, and default icons.