### PR TITLE
Deinit the gdolib before restarting.

### DIFF
--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -30,6 +30,7 @@ namespace secplus_gdo {
         void setup() override;
         void loop() override {};
         void dump_config() override;
+        void on_shutdown() override { gdo_deinit(); }
         // Use Late priority so we do not start the GDO lib until all saved preferences are loaded
         float get_setup_priority() const override { return setup_priority::LATE; }
 

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: GDO blaQ
   project_name: konnected.garage-door-gdov2-q
-  project_version: "1.1.0"
+  project_version: "1.1.1"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings


### PR DESCRIPTION
This prevents the door from being triggered when a restart command is sent by deinitializing the gdolib and uart before executing the restart.