### PR TITLE
GDO blaQ compatibility enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,6 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           
       - run: mkdir -p install-konnected/manifests
-        if: github.event.release  
 
       - name: Build Manifest for Alarm Panel / WiFi
         if: github.event.release  
@@ -207,7 +206,6 @@ jobs:
           MANIFEST_FNAME: esphome-gdov2-q-dev.json
           MANIFEST_VERSION: "${{ steps.garage-door-gdov2-q-version.outputs.data }}"          
           ESP32_S3_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-garage-door-gdov2-q.outputs.fname }}
-  
           
       - name: Build Manifest for Alarm Panel Pro v1.x / LAN8720
         if: github.event.release  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
         with:
           command: cp
           source: assets/
-          destination: s3://konnected-io/builds/esphome/
+          destination: s3://konnected-io/builds/esphome/${{ github.ref_name }}
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws_region: us-east-2
@@ -174,8 +174,8 @@ jobs:
           MANIFEST_NAME: Konnected Alarm Panel / Alarm Panel Pro for ESPHome (WiFi)
           MANIFEST_FNAME: esphome-alarm-panel-wifi.json
           MANIFEST_VERSION: "${{ steps.alarm-panel-esp8266-version.outputs.data }} / ${{ steps.alarm-panel-pro-wifi-version.outputs.data }}"
-          ESP8266_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ steps.build-alarm-panel-esp8266.outputs.fname }}
-          ESP32_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ steps.build-alarm-panel-pro-esp32-wifi.outputs.fname }}
+          ESP8266_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-alarm-panel-esp8266.outputs.fname }}
+          ESP32_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-alarm-panel-pro-esp32-wifi.outputs.fname }}
 
       - name: Build Manifest for GDO White
         if: github.event.release  
@@ -185,19 +185,30 @@ jobs:
           MANIFEST_NAME: Konnected GDO White (GDOv1-S / GDOv2-S) for ESPHome
           MANIFEST_FNAME: esphome-garage-door-wifi.json
           MANIFEST_VERSION: "${{ steps.garage-door-gdov1-s-version.outputs.data }} / ${{ steps.garage-door-gdov2-s-version.outputs.data }}"
-          ESP8266_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ steps.build-garage-door-gdov1-s.outputs.fname }}
-          ESP32_S3_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ steps.build-garage-door-gdov2-s.outputs.fname }}
+          ESP8266_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-garage-door-gdov1-s.outputs.fname }}
+          ESP32_S3_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-garage-door-gdov2-s.outputs.fname }}
 
       - name: Build Manifest for GDO blaQ
         if: github.event.release  
         run: |
           ruby ./scripts/update-espwebtools-manifests.rb
         env:
-          MANIFEST_NAME: Konnected GDO blaQ (GDOv2-Q) for ESPHome
+          MANIFEST_NAME: Konnected GDO blaQ (GDOv2-Q)
           MANIFEST_FNAME: esphome-gdov2-q.json
           MANIFEST_VERSION: "${{ steps.garage-door-gdov2-q-version.outputs.data }}"          
-          ESP32_S3_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ steps.build-garage-door-gdov2-q.outputs.fname }}
-            
+          ESP32_S3_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-garage-door-gdov2-q.outputs.fname }}
+
+      - name: Build Dev Manifest for GDO blaQ
+        if: github.ref_name == 'dev'
+        run: |
+          ruby ./scripts/update-espwebtools-manifests.rb
+        env:
+          MANIFEST_NAME: Konnected GDO blaQ (GDOv2-Q)[DEV]
+          MANIFEST_FNAME: esphome-gdov2-q-dev.json
+          MANIFEST_VERSION: "${{ steps.garage-door-gdov2-q-version.outputs.data }}"          
+          ESP32_S3_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-garage-door-gdov2-q.outputs.fname }}
+  
+          
       - name: Build Manifest for Alarm Panel Pro v1.x / LAN8720
         if: github.event.release  
         run: |
@@ -206,7 +217,7 @@ jobs:
           MANIFEST_NAME: Konnected Alarm Panel Pro v1.x for ESPHome (Ethernet)
           MANIFEST_FNAME: esphome-alarm-panel-lan8720.json
           MANIFEST_VERSION: "${{ steps.alarm-panel-pro-ethernet-version.outputs.data }}"
-          ESP32_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ steps.build-alarm-panel-pro-esp32-lan8720.outputs.fname }}
+          ESP32_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-alarm-panel-pro-esp32-lan8720.outputs.fname }}
 
       - name: Build Manifest for Alarm Panel Pro v1.8 / RTL8201
         if: github.event.release  
@@ -216,7 +227,7 @@ jobs:
           MANIFEST_NAME: Konnected Alarm Panel Pro v1.8 for ESPHome (Ethernet)
           MANIFEST_FNAME: esphome-alarm-panel-rtl8201.json
           MANIFEST_VERSION: "${{ steps.alarm-panel-pro-v18-ethernet-version.outputs.data }}"
-          ESP32_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ steps.build-alarm-panel-pro-esp32-rtl8201.outputs.fname }}
+          ESP32_IMAGE_URI: https://konnected-io.s3.us-east-2.amazonaws.com/builds/esphome/${{ github.ref_name }}/${{ steps.build-alarm-panel-pro-esp32-rtl8201.outputs.fname }}
       
       - name: Deploy
         if: github.event.release  

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.esphome/
 /secrets.yaml
 __pycache__/
+.vscode

--- a/components/secplus_gdo/cover/__init__.py
+++ b/components/secplus_gdo/cover/__init__.py
@@ -40,7 +40,6 @@ CoverClosingEndTrigger = secplus_gdo_ns.class_(
 CONF_PRE_CLOSE_WARNING_DURATION = "pre_close_warning_duration"
 CONF_PRE_CLOSE_WARNING_START = "pre_close_warning_start"
 CONF_PRE_CLOSE_WARNING_END = "pre_close_warning_end"
-CONF_TOGGLE_ONLY = "toggle_only"
 
 CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
     {
@@ -52,7 +51,6 @@ CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
         cv.Optional(CONF_PRE_CLOSE_WARNING_END): automation.validate_automation(
             {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverClosingEndTrigger)}
         ),
-        cv.Optional(CONF_TOGGLE_ONLY, default=False): cv.boolean,
     }
 ).extend(SECPLUS_GDO_CONFIG_SCHEMA)
 
@@ -62,10 +60,8 @@ async def to_code(config):
     await cg.register_component(var, config)
     await cover.register_cover(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    text = "std::bind(&" + str(GDODoor) + "::set_state," + str(config[CONF_ID]) + ",std::placeholders::_1,std::placeholders::_2)"
-    cg.add(parent.register_door(cg.RawExpression(text)))
+    cg.add(parent.register_door(var))
     cg.add(var.set_pre_close_warning_duration(config[CONF_PRE_CLOSE_WARNING_DURATION]))
-    cg.add(var.set_toggle_only(config[CONF_TOGGLE_ONLY]))
     for conf in config.get(CONF_PRE_CLOSE_WARNING_START, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         await automation.build_automation(trigger, [], conf)

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -45,7 +45,7 @@ using namespace esphome::cover;
         }
 
         void do_action(const cover::CoverCall& call);
-        void do_action_after_warning(const cover::CoverCall& call);        
+        void do_action_after_warning(const cover::CoverCall& call);
         void set_pre_close_warning_duration(uint32_t ms) { this->pre_close_duration_ = ms; }
         void set_toggle_only(bool val) { this->toggle_only_ = val; }
         void set_state(gdo_door_state_t state, float position);
@@ -55,9 +55,12 @@ using namespace esphome::cover;
 
         CoverClosingStartTrigger *pre_close_start_trigger{nullptr};
         CoverClosingEndTrigger   *pre_close_end_trigger{nullptr};
-        uint32_t                 pre_close_duration_{0};        
+        uint32_t                 pre_close_duration_{0};
         bool                     pre_close_active_{false};
         bool                     toggle_only_{false};
+        optional<float>          target_position_{0};
+        CoverOperation           prev_operation{COVER_OPERATION_IDLE};
+        gdo_door_state_t         state_{GDO_DOOR_STATE_MAX};
     };
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -117,6 +117,11 @@ namespace secplus_gdo {
     }
 
     void GDOComponent::setup() {
+        // Set the toggle only state and control here because we cannot guarantee the cover instance was created before the switch
+        this->door_->set_toggle_only(this->toggle_only_switch_->state);
+        this->toggle_only_switch_->set_control_function(std::bind(&esphome::secplus_gdo::GDODoor::set_toggle_only,
+                                                        this->door_, std::placeholders::_1));
+
         gdo_config_t gdo_conf = {
             .uart_num = UART_NUM_1,
             .obst_from_status = true,

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -21,6 +21,8 @@
 #include "number/gdo_number.h"
 #include "esphome/core/defines.h"
 #include "select/gdo_select.h"
+#include "switch/gdo_switch.h"
+#include "cover/gdo_door.h"
 #include "gdo.h"
 
 namespace esphome {
@@ -35,7 +37,9 @@ namespace secplus_gdo {
         float get_setup_priority() const override { return setup_priority::LATE; }
 
         void register_protocol_select(GDOSelect *select) { this->protocol_select_ = select; }
-        void set_protocol_state(gdo_protocol_type_t protocol) { if (this->protocol_select_) { this->protocol_select_->update_state(protocol); } }
+        void set_protocol_state(gdo_protocol_type_t protocol) { if (this->protocol_select_) {
+            this->protocol_select_->update_state(protocol); }
+        }
 
         void register_motion(std::function<void(bool)> f) { f_motion = f; }
         void set_motion_state(gdo_motion_state_t state) { if (f_motion) { f_motion(state == GDO_MOTION_STATE_DETECTED); } }
@@ -54,8 +58,8 @@ namespace secplus_gdo {
         void register_openings(std::function<void(uint16_t)> f) { f_openings = f; }
         void set_openings(uint16_t openings) { if (f_openings) { f_openings(openings); } }
 
-        void register_door(std::function<void(gdo_door_state_t, float)> f) { f_door = f; }
-        void set_door_state(gdo_door_state_t state, float position) { if (f_door) { f_door(state, position); } }
+        void register_door(GDODoor *door) { this->door_ = door; }
+        void set_door_state(gdo_door_state_t state, float position) { if (this->door_) { this->door_->set_state(state, position); } }
 
         void register_light(std::function<void(gdo_light_state_t)> f) { f_light = f; }
         void set_light_state(gdo_light_state_t state) { if (f_light) { f_light(state); } }
@@ -63,8 +67,10 @@ namespace secplus_gdo {
         void register_lock(std::function<void(gdo_lock_state_t)> f) { f_lock = f; }
         void set_lock_state(gdo_lock_state_t state) { if (f_lock) { f_lock(state); } }
 
-        void register_learn(std::function<void(bool)> f) { f_learn = f; }
-        void set_learn_state(gdo_learn_state_t state) { if (f_learn) { f_learn(state == GDO_LEARN_STATE_ACTIVE); } }
+        void register_learn(GDOSwitch *sw) { this->learn_switch_ = sw; }
+        void set_learn_state(gdo_learn_state_t state) { if (this->learn_switch_) {
+            this->learn_switch_->write_state(state == GDO_LEARN_STATE_ACTIVE); }
+        }
 
         void register_open_duration(GDONumber* num) { open_duration_ = num; }
         void set_open_duration(uint16_t ms ) { if (open_duration_) { open_duration_->update_state(ms); } }
@@ -78,9 +84,10 @@ namespace secplus_gdo {
         void register_rolling_code(GDONumber* num) { rolling_code_ = num; }
         void set_rolling_code(uint32_t num) { if (rolling_code_) { rolling_code_->update_state(num); } }
 
+        void register_toggle_only(GDOSwitch *sw) { this->toggle_only_switch_ = sw; }
+
     protected:
-        gdo_status_t status_;
-        std::function<void(gdo_door_state_t, float)> f_door{nullptr};
+        gdo_status_t                                 status_{};
         std::function<void(gdo_lock_state_t)>        f_lock{nullptr};
         std::function<void(gdo_light_state_t)>       f_light{nullptr};
         std::function<void(uint16_t)>                f_openings{nullptr};
@@ -88,12 +95,14 @@ namespace secplus_gdo {
         std::function<void(bool)>                    f_obstruction{nullptr};
         std::function<void(bool)>                    f_button{nullptr};
         std::function<void(bool)>                    f_motor{nullptr};
-        std::function<void(bool)>                    f_learn{nullptr};
+        GDODoor*                                     door_{nullptr};
         GDONumber*                                   open_duration_{nullptr};
         GDONumber*                                   close_duration_{nullptr};
         GDONumber*                                   client_id_{nullptr};
         GDONumber*                                   rolling_code_{nullptr};
         GDOSelect*                                   protocol_select_{nullptr};
+        GDOSwitch*                                   learn_switch_{nullptr};
+        GDOSwitch*                                   toggle_only_switch_{nullptr};
 
     }; // GDOComponent
 } // namespace secplus_gdo

--- a/components/secplus_gdo/select/__init__.py
+++ b/components/secplus_gdo/select/__init__.py
@@ -9,7 +9,7 @@ DEPENDENCIES = ["secplus_gdo"]
 
 GDOSelect = secplus_gdo_ns.class_("GDOSelect", select.Select, cg.Component)
 
-CONF_PROTOCOL_SELECT_OPTIONS = ["auto", "security+1.0", "security+2.0"]
+CONF_PROTOCOL_SELECT_OPTIONS = ["auto", "security+1.0", "security+2.0", "security+1.0 with smart panel"]
 
 CONFIG_SCHEMA = (
     select.select_schema(GDOSelect)

--- a/components/secplus_gdo/switch/__init__.py
+++ b/components/secplus_gdo/switch/__init__.py
@@ -12,6 +12,7 @@ GDOSwitch = secplus_gdo_ns.class_("GDOSwitch", switch.Switch, cg.Component)
 CONF_TYPE = "type"
 TYPES = {
     "learn": "register_learn",
+    "toggle_only": "register_toggle_only",
 }
 
 
@@ -32,5 +33,7 @@ async def to_code(config):
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
     fcall = str(parent) + "->" + str(TYPES[config[CONF_TYPE]])
-    text = fcall + "(std::bind(&" + str(GDOSwitch) + "::write_state," + str(config[CONF_ID]) + ",std::placeholders::_1))"
+    text = fcall + "(" + str(var) + ")"
     cg.add((cg.RawExpression(text)))
+    text = "secplus_gdo::SwitchType::" + str(config[CONF_TYPE]).upper()
+    cg.add(var.set_type(cg.RawExpression(text)))

--- a/components/secplus_gdo/switch/gdo_switch.h
+++ b/components/secplus_gdo/switch/gdo_switch.h
@@ -8,21 +8,61 @@
 #pragma once
 
 #include "esphome/components/switch/switch.h"
+#include "esphome/core/preferences.h"
 #include "esphome/core/component.h"
 #include "gdo.h"
 
 namespace esphome {
 namespace secplus_gdo {
 
+    enum SwitchType {
+        LEARN,
+        TOGGLE_ONLY,
+    };
+
     class GDOSwitch : public switch_::Switch, public Component {
     public:
-        void write_state(bool state) override {
-            if (state) {
-                gdo_activate_learn();
-            } else {
-                gdo_deactivate_learn();
+        void dump_config() override {}
+        void setup() override {
+            bool value = false;
+            this->pref_ = global_preferences->make_preference<bool>(this->get_object_id_hash());
+            if (!this->pref_.load(&value)) {
+                value = false;
             }
+
+            this->write_state(value);
         }
+
+        void write_state(bool state) override {
+            if (state == this->state) {
+                return;
+            }
+
+            if (this->type_ == SwitchType::TOGGLE_ONLY) {
+                if (this->f_control) {
+                    this->f_control(state);
+                    this->pref_.save(&state);
+                }
+            }
+
+            if (this->type_ == SwitchType::LEARN) {
+                if (state) {
+                    gdo_activate_learn();
+                } else {
+                    gdo_deactivate_learn();
+                }
+            }
+
+            this->publish_state(state);
+        }
+
+        void set_type(SwitchType type) { this->type_ = type; }
+        void set_control_function(std::function<void(bool)> f) { f_control = f; }
+
+    protected:
+        SwitchType                type_{SwitchType::LEARN};
+        std::function<void(bool)> f_control{nullptr};
+        ESPPreferenceObject       pref_;
     };
 
 } // namespace secplus_gdo

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -89,7 +89,7 @@ substitutions:
   status_led: GPIO18
 
 external_components:
-  - source: github://konnected-io/konnected-esphome@master
+  - source: github://konnected-io/konnected-esphome@door-op-fixes
     components: [ mdns, secplus_gdo ]
 
   # Un-comment below and comment above for local modification
@@ -106,7 +106,7 @@ packages:
 
   remote_package:
     url: https://github.com/konnected-io/konnected-esphome
-    ref: master
+    ref: door-op-fixes
     refresh: 5min
     files:
 
@@ -155,7 +155,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@master
+  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@door-op-fixes
   import_full_config: false
 
 ####
@@ -193,6 +193,6 @@ web_server:
 esphome:
   platformio_options:
     lib_deps:
-      - https://github.com/konnected-io/gdolib
+      - https://github.com/konnected-io/gdolib#command-delay-rx-fix
     build_flags:
       - -DUART_SCLK_DEFAULT=UART_SCLK_APB

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -88,7 +88,7 @@ substitutions:
   status_led: GPIO18
 
 external_components:
-  - source: github://konnected-io/konnected-esphome@dev
+  - source: github://konnected-io/konnected-esphome@master
     components: [ mdns, secplus_gdo ]
 
   # Un-comment below and comment above for local modification
@@ -105,7 +105,7 @@ packages:
 
   remote_package:
     url: https://github.com/konnected-io/konnected-esphome
-    ref: dev
+    ref: master
     refresh: 5min
     files:
 
@@ -154,7 +154,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@dev
+  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@master
   import_full_config: false
 
 ####
@@ -192,6 +192,6 @@ web_server:
 esphome:
   platformio_options:
     lib_deps:
-      - https://github.com/konnected-io/gdolib#dev
+      - https://github.com/konnected-io/gdolib
     build_flags:
       - -DUART_SCLK_DEFAULT=UART_SCLK_APB

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -83,7 +83,6 @@ substitutions:
   # DO NOT EDIT these when using Konnected hardware
   uart_tx_pin: GPIO1
   uart_rx_pin: GPIO2
-  input_obst_pin: GPIO5
   warning_beep_pin: GPIO4
   warning_leds_pin: GPIO3
   status_led: GPIO18
@@ -166,10 +165,10 @@ logger:
   # hardware_uart: UART0  -- uncomment on batch 2403; not needed on batch 2404 and newer
   logs:
     ledc.output: INFO
-    vl53l0x: DEBUG
     sensor: INFO
     json: INFO
     api: DEBUG
+    esp-idf: VERBOSE
 
 ####
 # NATIVE API

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: GDO blaQ
   project_name: konnected.garage-door-gdov2-q
-  project_version: "1.1.1"
+  project_version: "1.2.0"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings
@@ -89,7 +89,7 @@ substitutions:
   status_led: GPIO18
 
 external_components:
-  - source: github://konnected-io/konnected-esphome@door-op-fixes
+  - source: github://konnected-io/konnected-esphome@dev
     components: [ mdns, secplus_gdo ]
 
   # Un-comment below and comment above for local modification
@@ -106,7 +106,7 @@ packages:
 
   remote_package:
     url: https://github.com/konnected-io/konnected-esphome
-    ref: door-op-fixes
+    ref: dev
     refresh: 5min
     files:
 
@@ -155,7 +155,7 @@ packages:
 # Enables automatic discovery and upgrades via ESPHome Dashboard
 # more: https://esphome.io/guides/getting_started_hassio.html
 dashboard_import:
-  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@door-op-fixes
+  package_import_url: github://konnected-io/konnected-esphome/garage-door-GDOv2-Q.yaml@dev
   import_full_config: false
 
 ####
@@ -193,6 +193,6 @@ web_server:
 esphome:
   platformio_options:
     lib_deps:
-      - https://github.com/konnected-io/gdolib#command-delay-rx-fix
+      - https://github.com/konnected-io/gdolib#dev
     build_flags:
       - -DUART_SCLK_DEFAULT=UART_SCLK_APB

--- a/packages/core-esp32-s3.yaml
+++ b/packages/core-esp32-s3.yaml
@@ -14,11 +14,13 @@ esphome:
           id: device_id
           state: !lambda 'return get_mac_address();'
 
-esp32:  
+esp32:
   board: esp32-s3-devkitc-1
   framework:
     type: esp-idf
     version: recommended
+    sdkconfig_options:
+      CONFIG_LWIP_MAX_SOCKETS: "16"
 
 substitutions:
   status_led_inverted: "false"

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -74,6 +74,13 @@ switch:
     secplus_gdo_id: gdo_blaq
     name: Learn
     icon: mdi:plus-box
+  - platform: secplus_gdo
+    id: gdo_toggle_only
+    type: toggle_only
+    secplus_gdo_id: gdo_blaq
+    name: Toggle Only
+    icon: mdi:plus-box
+    entity_category: config
 
 select:
   - platform: secplus_gdo


### PR DESCRIPTION
1. Adds protocol option for Security+1.0 with smart panel (ie. 888/889LM) which disables panel emulation so the wall console won't get clobbered.
2. Adds _toggle_only_ option for Australia openers that do not respond to _close_ commands
3. Improves serial communication reliability and retry