### PR TITLE
GDO blaQ command parsing, reliability, sync and logging improvements

### DIFF
--- a/components/secplus_gdo/binary_sensor/__init__.py
+++ b/components/secplus_gdo/binary_sensor/__init__.py
@@ -36,6 +36,7 @@ TYPES = {
     "obstruction": "register_obstruction",
     "motor": "register_motor",
     "button": "register_button",
+    "sync": "register_sync",
 }
 
 

--- a/components/secplus_gdo/cover/gdo_door.cpp
+++ b/components/secplus_gdo/cover/gdo_door.cpp
@@ -23,6 +23,12 @@ void GDODoor::set_state(gdo_door_state_t state, float position) {
         }
     }
 
+    if (this->state_ == state && this->position == position) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "Door state: %s, position: %.0f%%", gdo_door_state_to_string(state), position * 100.0f);
+
     switch (state) {
     case GDO_DOOR_STATE_OPEN:
         this->position = COVER_OPEN;
@@ -141,6 +147,11 @@ void GDODoor::do_action(const cover::CoverCall& call) {
 }
 
 void GDODoor::control(const cover::CoverCall& call) {
+    if (!this->synced_) {
+        this->publish_state(false);
+        return;
+    }
+
     if (call.get_stop()) {
         ESP_LOGD(TAG, "Stop command received");
         if (this->pre_close_active_) {

--- a/components/secplus_gdo/cover/gdo_door.h
+++ b/components/secplus_gdo/cover/gdo_door.h
@@ -44,6 +44,10 @@ using namespace esphome::cover;
             this->pre_close_end_trigger = trigger;
         }
 
+        void set_sync_state(bool synced) {
+            this->synced_ = synced;
+        }
+
         void do_action(const cover::CoverCall& call);
         void do_action_after_warning(const cover::CoverCall& call);
         void set_pre_close_warning_duration(uint32_t ms) { this->pre_close_duration_ = ms; }
@@ -61,6 +65,7 @@ using namespace esphome::cover;
         optional<float>          target_position_{0};
         CoverOperation           prev_operation{COVER_OPERATION_IDLE};
         gdo_door_state_t         state_{GDO_DOOR_STATE_MAX};
+        bool                     synced_{false};
     };
 } // namespace secplus_gdo
 } // namespace esphome

--- a/components/secplus_gdo/light/__init__.py
+++ b/components/secplus_gdo/light/__init__.py
@@ -41,5 +41,4 @@ async def to_code(config):
     await cg.register_component(var, config)
     await light.register_light(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    text = "std::bind(&" + str(GDOLight) + "::set_state," + str(config[CONF_OUTPUT_ID]) + ",std::placeholders::_1)"
-    cg.add(parent.register_light(cg.RawExpression(text)))
+    cg.add(parent.register_light(var))

--- a/components/secplus_gdo/lock/__init__.py
+++ b/components/secplus_gdo/lock/__init__.py
@@ -41,5 +41,4 @@ async def to_code(config):
     await lock.register_lock(var, config)
     await cg.register_component(var, config)
     parent = await cg.get_variable(config[CONF_SECPLUS_GDO_ID])
-    text = "std::bind(&" + str(GDOLock) + "::set_state," + str(config[CONF_ID]) + ",std::placeholders::_1)"
-    cg.add(parent.register_lock(cg.RawExpression(text)))
+    cg.add(parent.register_lock(var))

--- a/components/secplus_gdo/lock/gdo_lock.h
+++ b/components/secplus_gdo/lock/gdo_lock.h
@@ -27,23 +27,22 @@ namespace secplus_gdo {
     class GDOLock : public lock::Lock, public Component {
         public:
         void set_state(gdo_lock_state_t state) {
-            if (state == GDO_LOCK_STATE_LOCKED && this->state == lock::LockState::LOCK_STATE_LOCKED) {
-                return;
-            }
-            if (state == GDO_LOCK_STATE_UNLOCKED && this->state == lock::LockState::LOCK_STATE_UNLOCKED) {
+            if (state == this->lock_state_) {
                 return;
             }
 
-            auto call = this->make_call();
-            if (state == GDO_LOCK_STATE_LOCKED) {
-                call.set_state(lock::LockState::LOCK_STATE_LOCKED);
-            } else if (state == GDO_LOCK_STATE_UNLOCKED) {
-                call.set_state(lock::LockState::LOCK_STATE_UNLOCKED);
-            }
-            this->control(call);
+            this->lock_state_ = state;
+            ESP_LOGI(TAG, "Lock state: %s", gdo_lock_state_to_string(state));
+            this->publish_state(state == GDO_LOCK_STATE_LOCKED ?
+                                         lock::LockState::LOCK_STATE_LOCKED :
+                                         lock::LockState::LOCK_STATE_UNLOCKED);
         }
 
         void control(const lock::LockCall& call) override {
+            if (!this->synced_) {
+                return;
+            }
+
             auto state = *call.get_state();
 
             if (state == lock::LockState::LOCK_STATE_LOCKED) {
@@ -51,9 +50,16 @@ namespace secplus_gdo {
             } else if (state == lock::LockState::LOCK_STATE_UNLOCKED) {
                 gdo_unlock();
             }
-
-            this->publish_state(state);
         }
+
+        void set_sync_state(bool synced) {
+            this->synced_ = synced;
+        }
+
+        private:
+        gdo_lock_state_t lock_state_{GDO_LOCK_STATE_MAX};
+        bool synced_{false};
+        static constexpr const char* TAG = "GDOLock";
     };
 
 } // namespace secplus_gdo

--- a/components/secplus_gdo/secplus_gdo.h
+++ b/components/secplus_gdo/secplus_gdo.h
@@ -23,6 +23,8 @@
 #include "select/gdo_select.h"
 #include "switch/gdo_switch.h"
 #include "cover/gdo_door.h"
+#include "light/gdo_light.h"
+#include "lock/gdo_lock.h"
 #include "gdo.h"
 
 namespace esphome {
@@ -57,17 +59,19 @@ namespace secplus_gdo {
         void register_motor(std::function<void(bool)> f) { f_motor = f; }
         void set_motor_state(gdo_motor_state_t state) { if (f_motor) { f_motor(state == GDO_MOTOR_STATE_ON); } }
 
+        void register_sync(std::function<void(bool)> f) { f_sync = f; }
+
         void register_openings(std::function<void(uint16_t)> f) { f_openings = f; }
         void set_openings(uint16_t openings) { if (f_openings) { f_openings(openings); } }
 
         void register_door(GDODoor *door) { this->door_ = door; }
         void set_door_state(gdo_door_state_t state, float position) { if (this->door_) { this->door_->set_state(state, position); } }
 
-        void register_light(std::function<void(gdo_light_state_t)> f) { f_light = f; }
-        void set_light_state(gdo_light_state_t state) { if (f_light) { f_light(state); } }
+        void register_light(GDOLight *light) { this->light_ = light; }
+        void set_light_state(gdo_light_state_t state) { if (this->light_) { this->light_->set_state(state); } }
 
-        void register_lock(std::function<void(gdo_lock_state_t)> f) { f_lock = f; }
-        void set_lock_state(gdo_lock_state_t state) { if (f_lock) { f_lock(state); } }
+        void register_lock(GDOLock *lock) { this->lock_ = lock; }
+        void set_lock_state(gdo_lock_state_t state) { if (this->lock_) { this->lock_->set_state(state); } }
 
         void register_learn(GDOSwitch *sw) { this->learn_switch_ = sw; }
         void set_learn_state(gdo_learn_state_t state) { if (this->learn_switch_) {
@@ -88,16 +92,19 @@ namespace secplus_gdo {
 
         void register_toggle_only(GDOSwitch *sw) { this->toggle_only_switch_ = sw; }
 
+        void set_sync_state(bool synced);
+
     protected:
         gdo_status_t                                 status_{};
-        std::function<void(gdo_lock_state_t)>        f_lock{nullptr};
-        std::function<void(gdo_light_state_t)>       f_light{nullptr};
         std::function<void(uint16_t)>                f_openings{nullptr};
         std::function<void(bool)>                    f_motion{nullptr};
         std::function<void(bool)>                    f_obstruction{nullptr};
         std::function<void(bool)>                    f_button{nullptr};
         std::function<void(bool)>                    f_motor{nullptr};
+        std::function<void(bool)>                    f_sync{nullptr};
         GDODoor*                                     door_{nullptr};
+        GDOLight*                                    light_{nullptr};
+        GDOLock*                                     lock_{nullptr};
         GDONumber*                                   open_duration_{nullptr};
         GDONumber*                                   close_duration_{nullptr};
         GDONumber*                                   client_id_{nullptr};

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -66,6 +66,7 @@ substitutions:
   garage_obstruction_name: Obstruction
   garage_motor_name: Motor
   garage_button_name: Wall Button
+  garage_sync_name: Synced
 
 
   ####
@@ -185,6 +186,6 @@ web_server:
 esphome:
   platformio_options:
     lib_deps:
-      - https://github.com/konnected-io/gdolib#4e6f493
+      - https://github.com/konnected-io/gdolib#dev
     build_flags:
       - -DUART_SCLK_DEFAULT=UART_SCLK_APB

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: GDO blaQ
   project_name: konnected.garage-door-gdov2-q
-  project_version: "1.2.5"
+  project_version: "1.3.0"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -186,6 +186,6 @@ web_server:
 esphome:
   platformio_options:
     lib_deps:
-      - https://github.com/konnected-io/gdolib#dev
+      - https://github.com/konnected-io/gdolib#76ba232
     build_flags:
       - -DUART_SCLK_DEFAULT=UART_SCLK_APB

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -66,6 +66,12 @@ binary_sensor:
     id: gdo_button
     secplus_gdo_id: gdo_blaq
     type: button
+  - platform: secplus_gdo
+    name: $garage_sync_name
+    id: gdo_synced
+    secplus_gdo_id: gdo_blaq
+    type: sync
+    device_class: connectivity
 
 switch:
   - platform: secplus_gdo


### PR DESCRIPTION
These changes are targeting the GDO blaQ v1.3.0:

1. Improves logging
2. Improves command parsing for Security+1.0 openers
3. Improves sync time for Security+2.0 openers
4. Adds a `synced` binary_sensor that represents the sync state (should be ON shortly after boot if properly connected)
5. Prevents commands from being sent until synced
6. Fixes _learn_ state parsing
