### PR TITLE
Wrap panic handler to prevent spurious door openings.

### DIFF
--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -172,3 +172,21 @@ namespace secplus_gdo {
 
 } // namespace secplus_gdo
 } // namespace esphome
+
+// Need to wrap the panic handler to disable the GDO TX pin and pull the output high to
+// prevent spuriously triggering the GDO to open when the ESP32 panics.
+extern "C" {
+#include "hal/gpio_hal.h"
+
+void __real_esp_panic_handler(void*);
+
+void __wrap_esp_panic_handler(void* info) {
+    esp_rom_printf("PANIC: DISABLING GDO UART TX PIN!\n");
+    gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[(gpio_num_t)GDO_UART_TX_PIN], PIN_FUNC_GPIO);
+    gpio_set_direction((gpio_num_t)GDO_UART_TX_PIN, GPIO_MODE_INPUT);
+    gpio_pulldown_en((gpio_num_t)GDO_UART_TX_PIN);
+
+    // Call the original panic handler
+    __real_esp_panic_handler(info);
+}
+} //extern "C"

--- a/garage-door-GDOv2-Q.yaml
+++ b/garage-door-GDOv2-Q.yaml
@@ -57,7 +57,7 @@ substitutions:
   name: konnected
   friendly_name: GDO blaQ
   project_name: konnected.garage-door-gdov2-q
-  project_version: "1.3.0"
+  project_version: "1.3.1"
   garage_door_cover_name: Garage Door
   garage_light_name: Garage Light
   garage_openings_name: Garage Openings
@@ -189,3 +189,4 @@ esphome:
       - https://github.com/konnected-io/gdolib#76ba232
     build_flags:
       - -DUART_SCLK_DEFAULT=UART_SCLK_APB
+      - -Wl,--wrap=esp_panic_handler


### PR DESCRIPTION
When the GDO-BlaQ is restarted by software through a watchdog timeout or `abort()` or `assert()`the reset process can leave the UART TX in a HIGH state, which causes the output to go LOW, triggering the garage door to open/close unexpectedly.  This adds a wrapper around the panic handler which switches the UART TX pin to a digital input with pulldown enabled which will cause the output to remain HIGH and avoid triggering the door.