### PR TITLE
Update false to none for esp32_improv

### DIFF
--- a/garage-door-GDOv2-S.yaml
+++ b/garage-door-GDOv2-S.yaml
@@ -209,6 +209,6 @@ logger:
 api:
 
 esp32_improv:
-  authorizer: false
+  authorizer: none
 
 web_server:

--- a/packages/wifi-esp32.yaml
+++ b/packages/wifi-esp32.yaml
@@ -6,7 +6,7 @@ improv_serial:
 captive_portal:
 
 esp32_improv:
-  authorizer: false
+  authorizer: none
 
 sensor:
   - platform: wifi_signal


### PR DESCRIPTION
ESPHome 2024.12.0 has a breaking change that does not allow `false` as the value for `authorizer` anymore. It needs to be an explicit `none` or an id of a binary sensor.