### PR TITLE
Use new platform syntax for esp8266

### DIFF
--- a/packages/core-esp8266.yaml
+++ b/packages/core-esp8266.yaml
@@ -2,9 +2,6 @@ esphome:
   name: $name
   friendly_name: $friendly_name
   name_add_mac_suffix: true
-  platform: ESP8266
-  board: nodemcuv2
-  esp8266_restore_from_flash: true
   project:
     name: $project_name
     version: $project_version
@@ -14,6 +11,11 @@ esphome:
       - text_sensor.template.publish:
           id: device_id
           state: !lambda 'return get_mac_address();'
+
+esp8266:
+  board: nodemcuv2
+  restore_from_flash: true
+
 
 substitutions:
   status_led_inverted: "true"


### PR DESCRIPTION
"Old style platform configuration" was [removed in ESPHome 2025.2.0](https://github.com/esphome/esphome/pull/8118).  This PR updates the esp8266 package to use the new syntax, and allows the alarm panel to build on 2025.2.