### PR TITLE
fix: replace `gpio_hal_iomux_func_sel` removed in ESP-IDF 5.5

### DIFF
--- a/components/secplus_gdo/secplus_gdo.cpp
+++ b/components/secplus_gdo/secplus_gdo.cpp
@@ -182,7 +182,7 @@ void __real_esp_panic_handler(void*);
 
 void __wrap_esp_panic_handler(void* info) {
     esp_rom_printf("PANIC: DISABLING GDO UART TX PIN!\n");
-    gpio_hal_iomux_func_sel(GPIO_PIN_MUX_REG[(gpio_num_t)GDO_UART_TX_PIN], PIN_FUNC_GPIO);
+    gpio_iomux_out((gpio_num_t)GDO_UART_TX_PIN, PIN_FUNC_GPIO, false);
     gpio_set_direction((gpio_num_t)GDO_UART_TX_PIN, GPIO_MODE_INPUT);
     gpio_pulldown_en((gpio_num_t)GDO_UART_TX_PIN);
 


### PR DESCRIPTION
Replace `gpio_hal_iomux_func_sel` with `gpio_iomux_out`. The latter is still deprecated, but the replacement function is in a private header file.

see #98 