### PR TITLE
Use a client ID that the opener will recognize as a wall panel.

### DIFF
--- a/components/secplus_gdo/number/__init__.py
+++ b/components/secplus_gdo/number/__init__.py
@@ -51,7 +51,7 @@ async def to_code(config):
     if "duration" in str(config[CONF_TYPE]):
         await number.register_number(var, config, min_value=0x0, max_value=0xffff, step=1)
     elif "client_id" in str(config[CONF_TYPE]):
-        await number.register_number(var, config, min_value=0x666, max_value=0x7ff666, step=1)
+        await number.register_number(var, config, min_value=0x0, max_value=0xffffffff, step=1)
     else:
         await number.register_number(var, config, min_value=0x0, max_value=0xffffffff, step=1)
     await cg.register_component(var, config)

--- a/packages/secplus-gdo.yaml
+++ b/packages/secplus-gdo.yaml
@@ -119,16 +119,12 @@ button:
     name: Re-sync
     entity_category: config
     on_press:
-      - if:
-          condition:
-            lambda: 'return id(gdo_client_id).state;'
-          then:
-            - number.increment:
-                id: gdo_client_id
-          else:
-            - number.set:
-                id: gdo_client_id
-                value: 0x667
+      - lambda: |-
+          // Generate random upper 16 bits, keep lower 16 bits as 0x2908
+          uint32_t random_upper = (esp_random() & 0x7F7F) << 16;
+          uint32_t client_id = random_upper | 0x2908;
+          ESP_LOGW("lambda","Re-syncing with Client ID: 0x%08X (%" PRIu32 ")", client_id, random_upper);
+          id(gdo_client_id).update_state(client_id);
       - number.set:
           id: gdo_rolling_code
           value: 0


### PR DESCRIPTION
This ensures the devices client id matches a wall panel device type which allows other devices connected to know of it and possibly prevent sync loss.