### PR TITLE
Fix secplus_gdo select build with ESPHome 2026.1.0

### DIFF
--- a/components/secplus_gdo/select/gdo_select.h
+++ b/components/secplus_gdo/select/gdo_select.h
@@ -39,7 +39,7 @@ namespace secplus_gdo {
         void update_state(gdo_protocol_type_t protocol) {
             if (this->has_index(protocol)) {
                 std::string value = this->at(protocol).value();
-                const char *current_option = this->current_option();
+                const char *current_option = this->current_option().c_str();
                 if (this->has_state() && value != current_option) {
                     this->pref_.save(&protocol);
                 }


### PR DESCRIPTION
ESPHome 2026.1.0 changed Select::current_option() to return StringRef, which breaks compilation where the code expects const char*. This updates current_option usage to call .c_str() and restores compatibility with ESPHome 2026.1.0+.
Verified working on Konnected GDO Blaq + Home Assistant ESPHome add-on.

Updated line 42 from
const char *current_option = this->current_option();
to:
const char *current_option = this->current_option().c_str();