### PR TITLE
migrate from get_object_id_hash() to make_entity_preference()

### DIFF
--- a/components/secplus_gdo/number/gdo_number.h
+++ b/components/secplus_gdo/number/gdo_number.h
@@ -29,7 +29,7 @@ class GDONumber : public number::Number, public Component {
         void dump_config() override {}
         void setup() override {
             float value;
-            this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+            this->pref_ = this->make_entity_preference<float>();
             if (!this->pref_.load(&value)) {
                 value = 0;
             }

--- a/components/secplus_gdo/select/gdo_select.h
+++ b/components/secplus_gdo/select/gdo_select.h
@@ -22,7 +22,7 @@ namespace secplus_gdo {
         void setup() override {
             std::string value;
             size_t index;
-            this->pref_ = global_preferences->make_preference<size_t>(this->get_object_id_hash());
+            this->pref_ = this->make_entity_preference<size_t>();
             if (!this->pref_.load(&index)) {
                 value = this->initial_option_;
             } else if (!this->has_index(index)) {

--- a/components/secplus_gdo/switch/gdo_switch.h
+++ b/components/secplus_gdo/switch/gdo_switch.h
@@ -25,7 +25,7 @@ namespace secplus_gdo {
         void dump_config() override {}
         void setup() override {
             bool value = false;
-            this->pref_ = global_preferences->make_preference<bool>(this->get_object_id_hash());
+            this->pref_ = this->make_entity_preference<bool>();
             if (!this->pref_.load(&value)) {
                 value = false;
             }

--- a/packages/core-esp32-s3.yaml
+++ b/packages/core-esp32-s3.yaml
@@ -2,7 +2,7 @@ esphome:
   name: $name
   friendly_name: $friendly_name
   name_add_mac_suffix: true
-  min_version: '2024.12.0' # Includes ESP-IDF 5.1
+  min_version: '2026.2.0' # Required for make_entity_preference() API (PR #13505)
   project:
     name: $project_name
     version: $project_version


### PR DESCRIPTION
Replace deprecated get_object_id_hash() API with the new make_entity_preference<T>() helper method introduced in [#13505](https://github.com/esphome/esphome/pull/13505). This change:

- Prevents hash collisions when entity names sanitize to the same string
- Enables automatic preference migration for future hash algorithm updates
- Uses device-aware hashing to avoid collisions across devices

Updated components:
- secplus_gdo switch, select, and number entities

Updated minimum ESPHome version to 2026.2.0 for all platforms (ESP32, ESP32-S3, ESP8266).

Fixes #106