### PR TITLE
Add arm_home and arm_night API services and buttons

### DIFF
--- a/alarm-panel-pro-esp32-local-alarm.yaml
+++ b/alarm-panel-pro-esp32-local-alarm.yaml
@@ -280,6 +280,18 @@ button:
         - state_machine.transition: arm_away
 
   - platform: template
+    name: Arm Home
+    on_press:
+      then:
+        - state_machine.transition: arm_home
+
+  - platform: template
+    name: Arm Night
+    on_press:
+      then:
+        - state_machine.transition: arm_night
+
+  - platform: template
     name: Disarm
     on_press:
       then:
@@ -407,12 +419,17 @@ logger:
 # more: https://esphome.io/components/api.html
 api:
   services:
-    - service: arm
-      then:
-        - state_machine.transition: arm_away
     - service: arm_away
       then:
         - state_machine.transition: arm_away
+
+    - service: arm_home
+      then:
+        - state_machine.transition: arm_home
+
+    - service: arm_night
+      then:
+        - state_machine.transition: arm_night
 
     - service: disarm
       variables:


### PR DESCRIPTION
The state machine defined armed_home and armed_night states with transitions from disarmed, but there were no API services or UI buttons to trigger them. Also removes the duplicate `arm` service that was identical to `arm_away`.