### PR TITLE
General Code Cleanup

### DIFF
--- a/alarm-panel-pro-esp32-ethernet.yaml
+++ b/alarm-panel-pro-esp32-ethernet.yaml
@@ -69,7 +69,6 @@ substitutions:
   alarm1: GPIO12
   alarm2: GPIO5
   out1: GPIO23
-  out2: GPIO5
   status_led: GPIO3
   
   ####

--- a/alarm-panel-pro-esp32-local-alarm.yaml
+++ b/alarm-panel-pro-esp32-local-alarm.yaml
@@ -73,7 +73,6 @@ substitutions:
   alarm1: GPIO12
   alarm2: GPIO5
   out1: GPIO23
-  out2: GPIO5
   status_led: GPIO3
 
   ####

--- a/alarm-panel-pro-esp32-local-alarm.yaml
+++ b/alarm-panel-pro-esp32-local-alarm.yaml
@@ -280,18 +280,6 @@ button:
         - state_machine.transition: arm_away
 
   - platform: template
-    name: Arm Home
-    on_press:
-      then:
-        - state_machine.transition: arm_home
-
-  - platform: template
-    name: Arm Night
-    on_press:
-      then:
-        - state_machine.transition: arm_night
-
-  - platform: template
     name: Disarm
     on_press:
       then:
@@ -419,17 +407,12 @@ logger:
 # more: https://esphome.io/components/api.html
 api:
   services:
+    - service: arm
+      then:
+        - state_machine.transition: arm_away
     - service: arm_away
       then:
         - state_machine.transition: arm_away
-
-    - service: arm_home
-      then:
-        - state_machine.transition: arm_home
-
-    - service: arm_night
-      then:
-        - state_machine.transition: arm_night
 
     - service: disarm
       variables:

--- a/alarm-panel-pro-esp32-local-alarm.yaml
+++ b/alarm-panel-pro-esp32-local-alarm.yaml
@@ -280,6 +280,18 @@ button:
         - state_machine.transition: arm_away
 
   - platform: template
+    name: Arm Home
+    on_press:
+      then:
+        - state_machine.transition: arm_home
+
+  - platform: template
+    name: Arm Night
+    on_press:
+      then:
+        - state_machine.transition: arm_night
+
+  - platform: template
     name: Disarm
     on_press:
       then:
@@ -407,12 +419,17 @@ logger:
 # more: https://esphome.io/components/api.html
 api:
   services:
-    - service: arm
-      then:
-        - state_machine.transition: arm_away
     - service: arm_away
       then:
         - state_machine.transition: arm_away
+
+    - service: arm_home
+      then:
+        - state_machine.transition: arm_home
+
+    - service: arm_night
+      then:
+        - state_machine.transition: arm_night
 
     - service: disarm
       variables:

--- a/alarm-panel-pro-esp32-wifi.yaml
+++ b/alarm-panel-pro-esp32-wifi.yaml
@@ -65,7 +65,6 @@ substitutions:
   alarm1: GPIO12
   alarm2: GPIO5
   out1: GPIO23
-  out2: GPIO5
   status_led: GPIO3
   
   ####

--- a/alarm-panel-pro-v1.8-ethernet.yaml
+++ b/alarm-panel-pro-v1.8-ethernet.yaml
@@ -69,7 +69,6 @@ substitutions:
   alarm1: GPIO12
   alarm2: GPIO5
   out1: GPIO23
-  out2: GPIO5
   status_led: GPIO3
   
   ####

--- a/packages/alarm-panel-esp32-base.yaml
+++ b/packages/alarm-panel-esp32-base.yaml
@@ -11,8 +11,6 @@ substitutions:
   # customize the name and hostname. Note: only lowercase characters, numbers and hyphen(-) are allowed.
   name: alarm-panel-pro
   friendly_name: Alarm Panel Pro
-  project_name: konnected.alarm-panel-pro-esp32-wifi
-  project_version: "0.4.0"
 
   sensor_debounce_time: 200ms
   warning_beep_pulse_time: 100ms

--- a/packages/alarm-panel-esp32-base.yaml
+++ b/packages/alarm-panel-esp32-base.yaml
@@ -39,7 +39,6 @@ substitutions:
   alarm1: GPIO12
   alarm2: GPIO5
   out1: GPIO23
-  out2: GPIO5
   status_led: GPIO3
   
   ####

--- a/packages/alarm-panel/alarm2.yaml
+++ b/packages/alarm-panel/alarm2.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  # Override to "true" in device config if alarm2 pin is a strapping pin with a safe pull-down.
   alarm2_ignore_strapping_warning: "false"
 
 switch:

--- a/packages/alarm-panel/relay1.yaml
+++ b/packages/alarm-panel/relay1.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  # Override to "true" in device config if relay1 pin is a strapping pin with a safe pull-down.
   relay1_ignore_strapping_warning: "false"
 
 switch:

--- a/packages/alarm-panel/relay2.yaml
+++ b/packages/alarm-panel/relay2.yaml
@@ -1,4 +1,5 @@
 substitutions:
+  # Override to "true" in device config if relay2 pin is a strapping pin with a safe pull-down.
   relay2_ignore_strapping_warning: "false"
 
 switch:

--- a/packages/gdo-self-test.yaml
+++ b/packages/gdo-self-test.yaml
@@ -1,3 +1,6 @@
+# REQUIRES: packages/vl53l0x-range-sensor.yaml must be included alongside this package.
+# References open_garage_door_distance_from_ceiling, garage_door_range_sensor, and range_sensor.
+
 substitutions:
   rtttl_boop: boop:d=32,o=5,b=100:d#
   rtttl_gotit: got_it:d=32,o=5,b=100:d#,a#,be
@@ -48,11 +51,6 @@ button:
     on_press:
       then:
         - script.execute: script_self_test_stop
-
-  - platform: factory_reset
-    name: Factory Reset
-    entity_category: diagnostic
-    internal: true
 
 script:
   - id: script_self_test


### PR DESCRIPTION
- Cleaned up several configuration issues across the alarm panel and garage door firmware:
Removed a duplicate GPIO5 pin assignment (out2) from all Alarm Panel Pro configs — it was mapped to the same pin as alarm2 and never actually used anywhere, which would have caused a conflict if it ever was.

- Removed stale project_name and project_version fields from the shared ESP32 base package. Every device config that imports it already defines its own values, so the ones in the base were dead defaults that made it look like the package owned versioning when it didn't.

- Added comments to the relay and alarm output packages explaining that the _ignore_strapping_warning flag should be overridden to true in any device config where that pin is a hardware-safe strapping pin. The alarm-panel-3e already does this correctly — it just wasn't obvious why.

- Added a required-dependency note to gdo-self-test.yaml — it references entities that only exist if vl53l0x-range-sensor.yaml is also included, which wasn't documented anywhere.

- Removed a duplicate factory reset button from gdo-self-test.yaml. The secplus-gdo package already defines one, and having both would cause a compile error on any device that includes both packages.