### PR TITLE
Correct range sensor tracking.

### DIFF
--- a/packages/vl53l0x-range-sensor.yaml
+++ b/packages/vl53l0x-range-sensor.yaml
@@ -46,12 +46,12 @@ binary_sensor:
     internal: true
     lambda: |-
       float calibrated_distance = id(open_garage_door_distance_from_ceiling).state;
-      if (std::isnan(id(range_sensor).state) || id(range_sensor).state > calibrated_distance + id(gdo_err_margin)) {
-        return false;
-      } else if (id(range_sensor).state > std::max(calibrated_distance - id(gdo_err_margin),0.0f)){
+      if (std::isnan(id(range_sensor).state)) {
+        return {};
+      } else if (std::abs(id(range_sensor).state - calibrated_distance) < id(gdo_err_margin)) {
         return true;
       } else {
-        return {};
+        return false;
       }
     filters:
       delayed_on_off: $range_sensor_debounce_time


### PR DESCRIPTION
The current behavior only checks if the current range is higher than the calibrated range plus the error range. The vl53l0x can drop to ~zero when the range is exceeded. This leads to the garage door sensor always thinking the garage door is open, if the range does not smoothly increase.

Instead, check if the sensor sees an object in the calibrated range plus or minus the error range.

This may fix https://github.com/konnected-io/konnected-esphome/issues/59